### PR TITLE
Use lowercase for all composer packages

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^6.5",
-        "mikey179/vfsStream": "^1.6",
+        "mikey179/vfsstream": "^1.6",
         "10up/wp_mock": "^0.3.0",
         "friendsofphp/php-cs-fixer": "^2.13"
     }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "ca0f2d12e0570fb4bfd55bb162d06c8e",
+    "content-hash": "8a7f9e8e564dd3f292dafe6889f51b9d",
     "packages": [
         {
             "name": "aura/autoload",
@@ -1524,6 +1524,7 @@
                 "mock",
                 "xunit"
             ],
+            "abandoned": true,
             "time": "2018-08-09T05:50:03+00:00"
         },
         {


### PR DESCRIPTION
As uppercase causes composer 2.0 to error.