### PR TITLE
Bump CHANGELOG to v1.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.3.0] - 2023-08-09
 
 ### Added
 


### PR DESCRIPTION
While preparing this release, I noticed that we never actually created tags for v1.2.0 or 1.2.1, so the last formal release was 1.1.1 (see https://packagist.org/packages/dxw/iguana). 

Reviewing the history, I don't think there's anything between 1.1.1 and now that should cause us any problems, but worth being aware of just in case, given that Iguana is in pretty much every project we build.