### PR TITLE
Release/v1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.3.1] - 2023-08-09
+### Removed
+- Version tag in `composer.json`
+
 ## [1.3.0] - 2023-08-09
 
 ### Added

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,7 @@
     "name": "dxw/iguana",
     "homepage": "https://github.com/dxw/iguana",
     "type": "library",
-    "version": "1.2.1",
+    "description": "Dependency injection framework for WordPress",
     "license": "MIT",
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
We've stopped using version numbers in `composer.json` for our other packages (because it's no longer the recommended approach), but we had a stray one here that didn't match the version number of our last release.