### PR TITLE
Fix/php8 deprecation notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Added
+- ArrayAccess return types for PHP 8 compatibility.
+
 ## [1.3.1] - 2023-08-09
 ### Removed
 - Version tag in `composer.json`

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,6 +1,6 @@
 <phpunit backupGlobals="true" colors="true">
   <testsuites>
-    <testsuite>
+    <testsuite name="iguana">
       <directory suffix="_test.php">tests</directory>
     </testsuite>
   </testsuites>

--- a/src/Value/ArrayBase.php
+++ b/src/Value/ArrayBase.php
@@ -17,22 +17,26 @@ abstract class ArrayBase implements \ArrayAccess
 		}
 	}
 
-	final public function offsetExists($offset)
+	final public function offsetExists($offset): bool
 	{
 		return isset($this->value[$offset]);
 	}
 
+	// PHP8 requires this method to have a return type of mixed
+	// But that is not PHP7-compatible
+	// So this attribute suppresses the warning for now
+	#[\ReturnTypeWillChange]
 	final public function offsetGet($offset)
 	{
 		return $this->value[$offset];
 	}
 
-	final public function offsetSet($offset, $value)
+	final public function offsetSet($offset, $value): void
 	{
 		throw new \Exception('cannot modify superglobals');
 	}
 
-	final public function offsetUnset($offset)
+	final public function offsetUnset($offset): void
 	{
 		throw new \Exception('cannot modify superglobals');
 	}

--- a/tests/registrar_test.php
+++ b/tests/registrar_test.php
@@ -2,6 +2,8 @@
 
 class MyUnregisterable
 {
+	private $name;
+
 	public function __construct(string $name = null)
 	{
 		$this->name = $name;


### PR DESCRIPTION
As I've started to work on running the dxw Extras integration & acceptance tests in PHP8, I've seen deprecation notices generated by Iguana popping up. This PR fixes those, but in a way that should also be PHP7-compatible.

To test:

While running PHP8.2, checkout the `main` branch of this repo and run `vendor/bin/phpunit`. You should see a number of deprecation warnings. Do the same on this branch and there are no warnings.