### PR TITLE
Prevent an "Undefined array key" error

### DIFF
--- a/src/Value/ArrayBase.php
+++ b/src/Value/ArrayBase.php
@@ -28,7 +28,11 @@ abstract class ArrayBase implements \ArrayAccess
 	#[\ReturnTypeWillChange]
 	final public function offsetGet($offset)
 	{
-		return $this->value[$offset];
+		if ($this->offsetExists($offset)) {
+			return $this->value[$offset];
+		} else {
+			return false;
+		}
 	}
 
 	final public function offsetSet($offset, $value): void


### PR DESCRIPTION
We're seeing the follwowing in logs when users are edited:

```
PHP Warning:  Undefined array key "dxwextras_deactivated" in phar:///usr/local/share/php/dxw-extras/vendor.phar/vendor/dxw/iguana/src/Value/ArrayBase.php on line 31
```

This is being triggered by the following call in dxw-extras:

```
if ($this->post['dxwextras_deactivated'] === 'yes') {
```

https://github.com/dxw/dxw-extras/blob/a116d941f645e0c08c68dfdc3242e5daa431d89a/src/DeactivatedUsers/UpdateOption.php#L36

Using `isset()` will still trigger the warning.